### PR TITLE
**How shall the eCl@ss group “Zusatzdokumentation (e.g. IRDI 0173-1#0…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Alternatively, an agile flexible approach using GITHUB has been defined. You may
 
 **How shall the eCl@ss group “Zusatzdokumentation (e.g. IRDI 0173-1#02-ADN464#..)” be used for documentation?**
 
-Please use the submodel template VDI 2770 for documentation instead.
+Please use the submodel template based on VDI 2770 for documentation instead. It will be released soon.
 (Answered: 2020-08-13)
 
 **How to treat values of Properties with values in multiple languages?**


### PR DESCRIPTION
…2-ADN464#..)” be used for documentation?**

Changed answer from **How shall the eCl@ss group “Zusatzdokumentation (e.g. IRDI 0173-1#02-ADN464#..)” be used for documentation?**
VDI2770 template is not yet released.