### PR TITLE
fix: multiple elements with the same semantic ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Submodel Templates guide the creation of Submodel Instances. Although the specif
 **[How should I name a submodel element if there are more than one with the same semanticId?](#id43)** <a id="id43"></a>
 
 There are several ways to deal with the topic of naming in the case that there is a set of elements (Referable/idShort), each with the same semanticId:
-* just number the elements (Example: Document01, Document02, Document{nn})
+* use SubmodelElementList as a collection of the element
 * assign a speaking name to each (Example: WheelFrontLeft, WheelFrontRight, WheelRearLeft, WheelRearRight)
 Via display names (introduced in V3.0RC01 Referable/displayName, it is also possible to assign more speaking names in a later stage if needed)
 


### PR DESCRIPTION
The section about multiple elements with the same semantic ids is outdated wrt. the current version of the spec. More precisely, it references the "allowDuplicates" attribute, which is not part of the current spec versions any longer. Furthermore, it suggests to model lists by assigning id shorts with numeric identifiers. With SubmodelElementLists there are alternative tools that are better suited for this purpose.