### PR TITLE
Clarification on ambiguous id shorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,10 @@ For choosing an idShort value there are the following recommendations (rules and
 
 In case a submodel template specification is used as a base, the idShort defined in this submodel template shall be used.
 
-Note: the isShort does not carry any semantic meaning. For speaking names the display name shall be used.
+Note: enumeration patterns (`IdShort__00__`) or the `SMT/AllowedIdShort` qualifiers, may lead to situations where an unambigious resolution of an idShort to a submodel element is impossible. Hence, when modeling,
+these features should be used cautiously. Their necessity/usefulness is currently in considerations.
+
+Note: the idShort does not carry any semantic meaning. For speaking names the display name shall be used.
 
 (Updated: 2021-05-17)
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Map concepts to “admin-shell.io” namespace (see [custom identifier best prac
 
 For choosing an idShort value there are the following recommendations (rules and order can be used for automatically creation of an idShort):
 
-- If an English shortname is available in the related concept description, the English shortName can be used as idShort. 
+- If an English shortName is available in the related concept description, the English shortName can be used as idShort. 
 - If there is an English preferredName available in the related concept description, this name can be converted to idShort, e.g. the preferredName “Maximum rotation speed” can be converted to “maximumRotationSpeed”.
 
 In case a submodel template specification is used as a base, the idShort defined in this submodel template shall be used.


### PR DESCRIPTION
With variable id shorts, e.g. for enumeration patterns and the
SMT/AllowedIdShort qualifier, it is possible to construct situations
where id short resolution is ambigious. Add a note that this may be the
case and that modelers have to take care not to create these situations.